### PR TITLE
fix #3

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -98,7 +98,10 @@ def show_room(day, year, room):
         title = event.find('title').text
         track = event.find('track').text
         subtitle = event.find('subtitle').text
-        persons = [p.text for p in event.find('./persons/person')]
+        try:
+            persons = [p.text for p in event.find('./persons/person')]
+        except TypeError:
+            persons = []
         abstract = event.find('abstract').text
         duration = event.find('duration').text
         if abstract:


### PR DESCRIPTION
Make persons an empty list in case the persons list provided by the xml document is empty.

With an empty list, this shows up nicely as "Cast not available" in Kodi.

The issue is with event id 8996 for which the persons list has no element, the speaker is instead part of the title - I think this is just a mistake.

Probably the data should be fixed, but this fix at least makes me capable of viewing videos from K.1.105 of day 1, 2019 :)