### PR TITLE
Fixed videos list menu when persons tag is empty

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -64,7 +64,8 @@ def show_dir(subdir=''):
         root = fetch_xml(subdir)
         for day in root.findall('day'):
             number = day.attrib['index']
-            text = 'Day {}'.format(number)
+            date = day.attrib['date']
+            text = 'Day {} ({})'.format(number, date)
             url = plugin.url_for(show_day, year=subdir, day=number)
             addDirectoryItem(plugin.handle, url,
                              ListItem(text), True)
@@ -80,9 +81,11 @@ def show_day(year, day):
             continue
 
         name = room.attrib['name']
+        genre = room.find('./event/track').text
+        text = '{} - {}'.format(name, genre)
         url = plugin.url_for(show_room, year=year, day=day, room=name)
         addDirectoryItem(plugin.handle, url,
-                         ListItem(name), True)
+                         ListItem(text), True)
     endOfDirectory(plugin.handle)
 
 
@@ -98,9 +101,10 @@ def show_room(day, year, room):
         title = event.find('title').text
         track = event.find('track').text
         subtitle = event.find('subtitle').text
-        persons = [p.text for p in event.find('./persons/person')]
+        person_items = event.find('./persons/person')
+        persons = [p.text for p in person_items] if person_items is not None else []
         abstract = event.find('abstract').text
-        duration = event.find('duration').text
+        duration = event.find('duration').text or '0:0'
         if abstract:
             abstract = abstract.replace('<p>', '').replace('</p>', '')
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.fosdem" name="FOSDEM Videos" version="0.0.2" provider-name="Jelle van der Waa">
+<addon id="plugin.video.fosdem" name="FOSDEM Videos" version="0.0.3" provider-name="Jelle van der Waa">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -22,6 +22,10 @@
 - Initial release
 v0.0.2
 - Support showing multiple years
+v0.0.3
+- Fixed videos list menu when persons tag is empty
+- Fixed option values at the settings menu
+- Added genres to the rooms list menu
 	</news>
         <disclaimer lang="en_GB">Unofficial Addon - Use at your own risk</disclaimer>
         <assets>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="format" type="enum" label="32001" lvalues="mp4|webm" default="0"/>
+    <setting id="format" type="enum" label="32001" values="mp4|webm" default="mp4"/>
 </settings>


### PR DESCRIPTION
Hi,

This is a PR in order to fix the persons empty field at the show_room function menu.

Besides of that, I've taken the chance to fix the video format options showed into the add-on settings menu, as well as include the topics along the room names for better visibility of what is exposed inside each room.

I've tried to make the smallest changes as possible and doing them alike you would.

You have done a very nice add-on and I enjoy it very much using it. I think with this PR the add-on is a bit improved and fully usable.

Please do not hesitate to review the code changes and remark anything you find it should be modified to keep your coding conventions and style. I've modified the addon.xml file reflecting the changes made as well, so once you are happy with the changes according to your criteria you can merge it and submit it directly to the official repository if you want it as is, avoiding additional commits to adapt the add-on for the official repo submit requirements, I hope.

Thanks a lot for your effort and time and best regards,

jamontes.