### PR TITLE
Added cache to store the yearly schedule

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.fosdem" name="FOSDEM Videos" version="0.0.3" provider-name="Jelle van der Waa">
+<addon id="plugin.video.fosdem" name="FOSDEM Videos" version="0.0.4" provider-name="Jelle van der Waa">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="script.module.requests" version="2.3.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>video</provides>
@@ -26,6 +25,9 @@ v0.0.3
 - Fixed videos list menu when persons tag is empty
 - Fixed option values at the settings menu
 - Added genres to the rooms list menu
+v0.0.4
+- Added cache to store the yearly schedule
+- Code changes to improve the performance through the navigation menus
 	</news>
         <disclaimer lang="en_GB">Unofficial Addon - Use at your own risk</disclaimer>
         <assets>


### PR DESCRIPTION
Hi,

This is a PR in order to add the cache feature for the yearly XML fetched on every add-on run. After tried several options between using cPickle to store the ET object and writing the raw XML data directly to disk, I've decided to split the whole XML on a daily basis, and write the raw serialized XML to a cache file per day. As the resultant XML file size is a little less than half of the size of the whole year schedule, the time to read and parse again the raw XML for the specific day from disk is really effective, so at the end I didn't use the cPickle library to make the cache feature.

As there is one cache file per day, I had to adapt the functions to use the day for loading the data instead of the year, and the tree searches now take the day as the root of the tree to parse.

The rest of modifications on this PR, besides the addition of the year into the info tags and to clean the abstract description from some HTML labels into the show_room function, was mainly focused into the task to improve the performance of loading the navigation menus throughout the add-on, specially noticeable on small hardware devices, like the Raspberry Pi and other well spread SoCs.

The most astonishing for me, after made the cache changes and tested it on my Raspberry Pi model 2, was that the add-on took still around 10 seconds to load the first page with the years list, and it didn't make any operation to fetch the year schedule from the internet nor the cache files! At first I thought of the lack of resources of the Raspi after upgraded recently to the latest KODI release, but then compared with other add-ons' behaviour I realized it had nothing to be with that, but with the time it takes for the add-on to load all the library dependencies before run. When I replaced the requests library by the urllib2 one, the first page (that never fetchs from the internet neither the disk the info to show) loaded within one second.

With that idea in mind, I've tried to reduce the dependency libraries imported to just the strictly required, and refactored the contains_videos function in order to return as soon as it finds a playable video available, instead of let it iterate along the tree downstream until find all the URL videos. As this function is called for every room and for every event inside each room, the change improved the response time in parsing the info along the XML as well. I'm very sorry to replace your really nice functional-style sentence of code on behalf of a more primitive and less elegant one, but the time reduced by this modification is impressive, and that's the reason why I've modified that function as well.

As with the other PR, please, do not hesitate to review the code and remark anything you find it should be modified in order to let it be according to your coding conventions and requirements.

Once again, thanks a lot for your effort and time, and best regards,

jamontes.